### PR TITLE
InvariantCulture in DateTime ToString()

### DIFF
--- a/src/CodeAnalyzer.Test/DateTimeStringAnalyzerTests.cs
+++ b/src/CodeAnalyzer.Test/DateTimeStringAnalyzerTests.cs
@@ -1,0 +1,75 @@
+﻿using CodeAnalyzer.Analyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using TestHelper;
+
+namespace CodeAnalyzer.Test
+{
+	[TestClass]
+	public class DateTimeStringAnalyzerTests : CodeFixVerifier
+	{
+		[TestMethod]
+		public void DateTimeStringAnalyzer_ToStringWitInvarientCulture_Ignore()
+		{
+			var test = @"
+using System;
+using System.Globalization;
+namespace ConsoleApplication1
+{
+	class TypeName
+	{   
+		static void Main(string[] args)
+		{
+			var date = DateTime.UtcNow.ToString(""yyyy/MM/dd"", CultureInfo.InvariantCulture);
+		}
+	}
+}";
+
+			VerifyCSharpDiagnostic(test);
+		}
+
+		[TestMethod]
+		public void DateTimeStringAnalyzer_ToStringWithoutInvarientCulture_ProposeFix()
+		{
+			var test = @"
+using System;
+using System.Globalization;
+namespace ConsoleApplication1
+{
+	class TypeName
+	{   
+		static void Main(string[] args)
+		{
+			var date = DateTime.UtcNow.ToString(""yyyy/MM/dd"");
+		}
+	}
+}";
+
+			var expected = new DiagnosticResult
+			{
+				Id = "DateTimeInvariantCulture",
+				Message = String.Format("Use InvariantCulture when printing date"),
+				Severity = DiagnosticSeverity.Warning,
+				Locations =
+					new[] { new DiagnosticResultLocation("Test0.cs", 10, 15) }
+			};
+
+			VerifyCSharpDiagnostic(test, expected);
+		}
+
+
+
+		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		{
+			return null;
+		}
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			return new DateTimeStringAnalyzer();
+		}
+	}
+}

--- a/src/CodeAnalyzer/Analyzers/DateTimeStringAnalyzer.cs
+++ b/src/CodeAnalyzer/Analyzers/DateTimeStringAnalyzer.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace CodeAnalyzer.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class DateTimeStringAnalyzer : DiagnosticAnalyzer
+	{
+		public const string DiagnosticId = "DateTimeInvariantCulture";
+		private const string Title = "InvariantCulture for DateTime";
+		private const string MessageFormat = "Use InvariantCulture when printing date";
+		private const string Description = "Use InvariantCulture when calling ToString() on DateTime";
+		private const string Category = "Usage";
+
+		private static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.RegisterCompilationStartAction(startContext =>
+			{
+				INamedTypeSymbol dateTimeSymbol = startContext.Compilation.GetTypeByMetadataName("System.DateTime");
+
+				if (dateTimeSymbol != null)
+				{
+					startContext.RegisterSyntaxNodeAction(
+						nodeContext => AnalyzeInvocationExpressionSyntax(nodeContext, dateTimeSymbol),
+						SyntaxKind.InvocationExpression);
+				}
+			});
+		}
+
+		private static void AnalyzeInvocationExpressionSyntax(SyntaxNodeAnalysisContext context, INamedTypeSymbol doubleSymbol)
+		{
+			var invocationExpressionSyntax = (InvocationExpressionSyntax)context.Node;
+
+			ISymbol symbol = context.SemanticModel.GetSymbol(invocationExpressionSyntax, context.CancellationToken);
+
+			INamedTypeSymbol containingType = symbol.ContainingType;
+
+			if (containingType?.Equals(doubleSymbol) == true)
+			{
+				if (symbol.Kind == SymbolKind.Method
+					&& (symbol.Name == "ToString"))
+				{
+					SeparatedSyntaxList<ArgumentSyntax> arguments = invocationExpressionSyntax.ArgumentList.Arguments;
+
+					if (!arguments.Any())
+						return;
+
+					if (!arguments.Any(e => e.Expression.TryGetInferredMemberName() == "InvariantCulture"))
+					{
+						context.ReportDiagnostic(Diagnostic.Create(Rule, context.Node.GetLocation()));
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added analyzer to check if InvariantCulture is used when calling ToString() on a DateTime object.

Fixes #16 